### PR TITLE
LON-544 Fix rendering of events with multiple drawings

### DIFF
--- a/LongoMatch.Drawing/Utils.cs
+++ b/LongoMatch.Drawing/Utils.cs
@@ -95,7 +95,9 @@ namespace LongoMatch.Drawing
 					obj.Draw (tk, null);
 					obj.Dispose ();
 				}
-				tk.DrawImage (fd.Freehand);
+				if (fd.Freehand != null) {
+					tk.DrawImage (fd.Freehand);
+				}
 			}
 			img = surface.Copy ();
 			surface.Dispose ();

--- a/LongoMatch.Services/RenderingJobsManager.cs
+++ b/LongoMatch.Services/RenderingJobsManager.cs
@@ -247,7 +247,7 @@ namespace LongoMatch.Services
 			} else {
 				file = element.Play.FileSet [cameraIndex];
 			}
-			drawings = play.Drawings.Where (d => d.CameraConfig.Index == cameraIndex);
+			drawings = play.Drawings.Where (d => d.CameraConfig.Index == cameraIndex).OrderBy (d => d.Render.MSeconds);
 
 			if (file == null || drawings == null) {
 				return false;

--- a/Tests/Services/TestRenderingJobsManager.cs
+++ b/Tests/Services/TestRenderingJobsManager.cs
@@ -26,80 +26,188 @@ using LongoMatch.Core.Store.Playlists;
 using LongoMatch.Services;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using LongoMatch.Core.Interfaces.Drawing;
+using LongoMatch.Drawing.Cairo;
 
 namespace Tests.Services
 {
-	[TestFixture ()]
+	[TestFixture]
 	public class TestRenderingJobsManager
 	{
+		Mock<IVideoEditor> editorMock;
+		string file1, file2;
+
+		[TestFixtureSetUp]
+		public void Setup ()
+		{
+			file1 = Path.GetTempFileName ();
+			file2 = Path.GetTempFileName ();
+		}
+
+		[TestFixtureTearDown]
+		public void TearDown ()
+		{
+			try {
+				File.Delete (file1);
+				File.Delete (file2);
+			} catch {
+			}
+		}
+
+		[SetUp]
+		public void SetupMocks ()
+		{
+			editorMock = new Mock<IVideoEditor> ();
+
+			var capturerMock = new Mock<IFramesCapturer> ();
+			capturerMock.Setup (c =>
+				c.GetFrame (It.IsAny<Time> (), It.IsAny<bool> (), It.IsAny<int> (), It.IsAny<int> ())).
+			Returns (Utils.LoadImageFromFile ());
+
+			// Mock IMultimediaToolkit
+			var mtk = new Mock <IMultimediaToolkit> ();
+			mtk.Setup (m => m.GetVideoEditor ()).Returns (editorMock.Object);
+			mtk.Setup (m => m.GetFramesCapturer ()).Returns (capturerMock.Object);
+
+			// and guitoolkit
+			var gtk = Mock.Of<IGUIToolkit> (g => g.RenderingStateBar == Mock.Of<IRenderingStateBar> ());
+
+			// And eventbroker
+			Config.EventsBroker = Mock.Of<EventsBroker> ();
+			Config.GUIToolkit = gtk;
+			Config.MultimediaToolkit = mtk.Object;
+			Config.DrawingToolkit = new CairoBackend ();
+		}
+
 		[Test ()]
 		public void TestRenderedCamera ()
 		{
 			Project p = Utils.CreateProject ();
 
 			try {
+				EditionJob job;
+				RenderingJobsManager renderer;
+
+				PrepareEditon (out job, out renderer);
+
 				TimelineEvent evt = p.Timeline [0];
 				evt.CamerasConfig = new ObservableCollection<CameraConfig> { new CameraConfig (0) };
 				PlaylistPlayElement element = new PlaylistPlayElement (evt);
-
-				// Playlist with one event
-				var playlist = new Playlist ();
-				playlist.Elements.Add (element);
-
-				// Create a job
-				const string outputFile = "path";
-				EncodingSettings settings = new EncodingSettings (VideoStandards.P720, EncodingProfiles.MP4, EncodingQualities.Medium,
-					                            25, 1, outputFile, true, true, 20);
-				EditionJob job = new EditionJob (playlist, settings);
-
-				// Mock IMultimediaToolkit and video editor
-				var mtk = Mock.Of<IMultimediaToolkit> (m => m.GetVideoEditor () == Mock.Of<IVideoEditor> ());
-				// and guitoolkit
-				var gtk = Mock.Of<IGUIToolkit> (g => g.RenderingStateBar == Mock.Of<IRenderingStateBar> ());
-				// and a video editor
-				Mock<IVideoEditor> mock = Mock.Get<IVideoEditor> (mtk.GetVideoEditor ());
-				// And eventbroker
-				Config.EventsBroker = Mock.Of<EventsBroker> ();
-				Config.GUIToolkit = gtk;
-				Config.MultimediaToolkit = mtk;
-
-				// Create a rendering object with mocked interfaces
-				RenderingJobsManager renderer = new RenderingJobsManager ();
-				// Start service
-				renderer.Start ();
+				job.Playlist.Elements.Add (element);
 
 				renderer.AddJob (job);
 
 				// Check that AddSegment is called with the right video file.
-				mock.Verify (m => m.AddSegment (p.Description.FileSet [0].FilePath,
+				editorMock.Verify (m => m.AddSegment (p.Description.FileSet [0].FilePath,
 					evt.Start.MSeconds, evt.Stop.MSeconds, evt.Rate, evt.Name, true, new Area ()), Times.Once ()); 
 
 				/* Test with a camera index bigger than the total cameras */
 				renderer.CancelAllJobs ();
-				mock.ResetCalls ();
+				editorMock.ResetCalls ();
 				evt = p.Timeline [1];
 				evt.CamerasConfig = new ObservableCollection<CameraConfig> { new CameraConfig (1) };
 				element = new PlaylistPlayElement (evt);
-				playlist.Elements [0] = element; 
-				job = new EditionJob (playlist, settings);
+				job.Playlist.Elements [0] = element; 
+				job.State = JobState.NotStarted;
 				renderer.AddJob (job);
-				mock.Verify (m => m.AddSegment (p.Description.FileSet [1].FilePath,
+				editorMock.Verify (m => m.AddSegment (p.Description.FileSet [1].FilePath,
 					evt.Start.MSeconds, evt.Stop.MSeconds, evt.Rate, evt.Name, true, new Area ()), Times.Once ()); 
 
 				/* Test with the secondary camera */
 				renderer.CancelAllJobs ();
-				mock.ResetCalls ();
+				editorMock.ResetCalls ();
 				evt = p.Timeline [1];
 				evt.CamerasConfig = new ObservableCollection<CameraConfig> { new CameraConfig (2) };
 				element = new PlaylistPlayElement (evt);
-				playlist.Elements [0] = element; 
-				job = new EditionJob (playlist, settings);
+				job.Playlist.Elements [0] = element; 
+				job.State = JobState.NotStarted;
 				renderer.AddJob (job);
-				mock.Verify (m => m.AddSegment (p.Description.FileSet [0].FilePath,
+				editorMock.Verify (m => m.AddSegment (p.Description.FileSet [0].FilePath,
 					evt.Start.MSeconds, evt.Stop.MSeconds, evt.Rate, evt.Name, true, new Area ()), Times.Once ()); 
 			} finally {
 				Utils.DeleteProject (p);
 			}
+		}
+
+		[Test ()]
+		public void TestLoadEditionJob ()
+		{
+			EditionJob job;
+			RenderingJobsManager renderer;
+
+			PrepareEditon (out job, out renderer);
+
+			AddTimelineEvent (job.Playlist, 30000, 31000, file1);
+			AddTimelineEvent (job.Playlist, 10000, 15000, file2);
+			AddTimelineEvent (job.Playlist, 43000, 46000, file2);
+			AddTimelineEvent (job.Playlist, 0, 0, "Does not exists");
+			AddTimelineEvent (job.Playlist, 86000, 90000, file1);
+			AddTimelineEvent (job.Playlist, 0, 0, "Does not exists");
+
+			renderer.AddJob (job);
+
+			editorMock.Verify (m => m.AddSegment (file1, 30000, 1000, 1, null, false, new Area ()));
+			editorMock.Verify (m => m.AddSegment (file2, 10000, 5000, 1, null, false, new Area ()));
+			editorMock.Verify (m => m.AddSegment (file2, 43000, 3000, 1, null, false, new Area ()));
+			editorMock.Verify (m => m.AddSegment (file1, 86000, 4000, 1, null, false, new Area ()));
+		}
+
+		[Test ()]
+		public void TestLoadEditionJobWithDrawingsInEvents ()
+		{
+			EditionJob job;
+			RenderingJobsManager renderer;
+			TimelineEvent evt;
+
+			PrepareEditon (out job, out renderer);
+			AddTimelineEvent (job.Playlist, 0, 10000, file1);
+
+			evt = (job.Playlist.Elements [0] as PlaylistPlayElement).Play;
+			evt.Drawings.Add (new FrameDrawing { Render = new Time (5000) });
+			evt.Drawings.Add (new FrameDrawing { Render = new Time (2000) });
+			evt.Drawings.Add (new FrameDrawing { Render = new Time (8000) });
+
+			renderer.AddJob (job);
+
+			editorMock.Verify (m => m.AddSegment (file1, 0, 2000, 1, null, false, new Area ()));
+			editorMock.Verify (m => m.AddImageSegment (It.IsAny<string> (), 0, 5000, null, new Area ()));
+			editorMock.Verify (m => m.AddSegment (file1, 2000, 3000, 1, null, false, new Area ()));
+			editorMock.Verify (m => m.AddImageSegment (It.IsAny<string> (), 0, 5000, null, new Area ()));
+			editorMock.Verify (m => m.AddSegment (file1, 5000, 3000, 1, null, false, new Area ()));
+			editorMock.Verify (m => m.AddImageSegment (It.IsAny<string> (), 0, 5000, null, new Area ()));
+			editorMock.Verify (m => m.AddSegment (file1, 8000, 2000, 1, null, false, new Area ()));
+		}
+
+		void PrepareEditon (out EditionJob job, out RenderingJobsManager renderer)
+		{
+			var playlist = new Playlist ();
+
+			const string outputFile = "path";
+			EncodingSettings settings = new EncodingSettings (VideoStandards.P720, EncodingProfiles.MP4,
+				                            EncodingQualities.Medium, 25, 1, outputFile, true, true, 20);
+
+			job = new EditionJob (playlist, settings);
+
+			// Create a rendering object with mocked interfaces
+			renderer = new RenderingJobsManager ();
+
+			// Start service
+			renderer.Start ();
+		}
+
+		void AddTimelineEvent (Playlist playlist, int start, int stop, string file)
+		{
+			MediaFileSet fileset = new MediaFileSet ();
+			fileset.Add (new MediaFile { FilePath = file });
+			TimelineEvent evt = new TimelineEvent {
+				Start = new Time (start),
+				Stop = new Time (stop),
+				FileSet = fileset,
+			};
+			playlist.Elements.Add (new PlaylistPlayElement (evt));
 		}
 	}
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -133,6 +133,10 @@
       <Project>{709CCDA6-CA95-4CBD-A986-B96EE0418905}</Project>
       <Name>LongoMatch.Addins</Name>
     </ProjectReference>
+    <ProjectReference Include="..\LongoMatch.Drawing.Cairo\LongoMatch.Drawing.Cairo.csproj">
+      <Project>{AE98609B-353C-4CE4-A5B7-606BB4EE3576}</Project>
+      <Name>LongoMatch.Drawing.Cairo</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Core\dibujo.svg">


### PR DESCRIPTION
Drawings need to be added sorted by their rendering time to have
segments in the editor with the correct positions