### PR TITLE
Add the option to load FileSet if Files doesn't exist

### DIFF
--- a/LongoMatch.Core/Interfaces/GUI/IGUIToolkit.cs
+++ b/LongoMatch.Core/Interfaces/GUI/IGUIToolkit.cs
@@ -116,7 +116,7 @@ namespace LongoMatch.Core.Interfaces.GUI
 
 		EndCaptureResponse EndCapture (bool isCapturing);
 
-		bool SelectMediaFiles (Project project);
+		bool SelectMediaFiles (MediaFileSet fileSet);
 
 		HotKey SelectHotkey (HotKey hotkey, object parent = null);
 

--- a/LongoMatch.Core/StyleConf.cs
+++ b/LongoMatch.Core/StyleConf.cs
@@ -152,6 +152,8 @@ namespace LongoMatch.Core.Common
 		public const string LinkOut = "icons/hicolor/scalable/actions/longomatch-link-out" + IMAGE_EXT;
 		public const string LinkOutPrelight = "icons/hicolor/scalable/actions/longomatch-link-out-prelight" + IMAGE_EXT;
 
+		public const string ButtonAlert = "icons/hicolor/scalable/actions/longomatch-alert" + IMAGE_EXT;
+
 		public const int FilterTreeViewToogleWidth = 30;
 
 		public string Font = "Ubuntu";

--- a/LongoMatch.Drawing/CanvasObjects/ButtonObject.cs
+++ b/LongoMatch.Drawing/CanvasObjects/ButtonObject.cs
@@ -211,10 +211,10 @@ namespace LongoMatch.Drawing.CanvasObjects
 			if (Active) {
 				tk.LineWidth = StyleConf.ButtonLineWidth;
 				front = BackgroundColor;
-				back = TextColor;
+				back = BorderColor;
 			} else {
 				tk.LineWidth = 0;
-				front = TextColor;
+				front = BorderColor;
 				back = BackgroundColor;
 			}
 			tk.FillColor = back;

--- a/LongoMatch.Drawing/CanvasObjects/Dashboard/DashboardButtonObject.cs
+++ b/LongoMatch.Drawing/CanvasObjects/Dashboard/DashboardButtonObject.cs
@@ -121,7 +121,7 @@ namespace LongoMatch.Drawing.CanvasObjects.Dashboard
 
 		public override Color BorderColor {
 			get {
-				return Button.BackgroundColor;
+				return Button.TextColor;
 			}
 		}
 

--- a/LongoMatch.Drawing/SelectionCanvas.cs
+++ b/LongoMatch.Drawing/SelectionCanvas.cs
@@ -265,6 +265,12 @@ namespace LongoMatch.Drawing
 			}
 
 			so = sel.Drawable as ICanvasSelectableObject;
+
+			if (so == null) {
+				return;
+			}
+				
+
 			if (Selections.Count > 0) {
 				if (SingleSelectionObjects.Contains (so.GetType ()) ||
 				    SingleSelectionObjects.Contains (Selections [0].Drawable.GetType ())) {

--- a/LongoMatch.GUI/Gui/GUIToolkit.cs
+++ b/LongoMatch.GUI/Gui/GUIToolkit.cs
@@ -446,7 +446,7 @@ namespace LongoMatch.Gui
 			return (EndCaptureResponse)res;
 		}
 
-		public bool SelectMediaFiles (Project project)
+		public bool SelectMediaFiles (MediaFileSet fileSet)
 		{
 			bool ret = false;
 			MediaFileSetSelection fileselector = new MediaFileSetSelection (false);
@@ -456,7 +456,7 @@ namespace LongoMatch.Gui
 				               Gtk.Stock.Cancel, ResponseType.Cancel,
 				               Gtk.Stock.Ok, ResponseType.Ok);
 			fileselector.Show ();
-			fileselector.FileSet = project.Description.FileSet;
+			fileselector.FileSet = fileSet;
 			d.VBox.Add (fileselector);
 			WarningMessage (Catalog.GetString ("Some video files are missing for this project"));
 			while (d.Run () == (int)ResponseType.Ok) {
@@ -475,7 +475,7 @@ namespace LongoMatch.Gui
 				// We need to update the fileset as it might have changed. Indeed if multi camera is not supported
 				// widget will propose only one media file selector and will return a smaller fileset than the 
 				// one provided originally.
-				project.Description.FileSet = fileselector.FileSet;
+				fileSet = fileselector.FileSet;
 			}
 			d.Destroy ();
 			return ret;

--- a/LongoMatch.Services/ProjectsManager.cs
+++ b/LongoMatch.Services/ProjectsManager.cs
@@ -170,7 +170,7 @@ namespace LongoMatch.Services
 			if (projectType == ProjectType.FileProject) {
 				// Check if the file associated to the project exists
 				if (!project.Description.FileSet.CheckFiles ()) {
-					if (!guiToolkit.SelectMediaFiles (project)) {
+					if (!guiToolkit.SelectMediaFiles (project.Description.FileSet)) {
 						CloseOpenedProject (true);
 						return false;
 					}

--- a/Tests/Integration/TestPostGameAnalysis.cs
+++ b/Tests/Integration/TestPostGameAnalysis.cs
@@ -70,7 +70,7 @@ namespace Tests.Integration
 
 			guiToolkitMock = new Mock<IGUIToolkit> ();
 			guiToolkitMock.Setup (g => g.RenderingStateBar).Returns (() => new Mock<IRenderingStateBar> ().Object);
-			guiToolkitMock.Setup (g => g.SelectMediaFiles (It.IsAny<Project> ())).Returns (true);
+			guiToolkitMock.Setup (g => g.SelectMediaFiles (It.IsAny<MediaFileSet> ())).Returns (true);
 			guiToolkitMock.Setup (g => g.BusyDialog (It.IsAny<string> (), It.IsAny<object> ())).Returns (
 				() => new DummyBusyDialog ());
 

--- a/Tests/Services/TestToolsManager.cs
+++ b/Tests/Services/TestToolsManager.cs
@@ -131,7 +131,7 @@ namespace Tests.Services
 			importer.ImportFunction = () => p;
 			Config.EventsBroker.EmitImportProject ();
 			dbMock.Verify (db => db.Store<Project> (p, true), Times.Once ());
-			guiToolkitMock.Verify (g => g.SelectMediaFiles (It.IsAny<Project> ()), Times.Never ());
+			guiToolkitMock.Verify (g => g.SelectMediaFiles (It.IsAny<MediaFileSet> ()), Times.Never ());
 			Assert.IsTrue (openned);
 		}
 

--- a/data/icons/Makefile.am
+++ b/data/icons/Makefile.am
@@ -2,6 +2,7 @@ iconsdir = @datadir@/@PACKAGE@/icons
 nobase_dist_icons_DATA = Makefile.am \
 	hicolor/index.theme \
 	hicolor/scalable/actions/longomat-project.svg \
+	hicolor/scalable/actions/longomatch-alert.svg \
 	hicolor/scalable/actions/longomatch-angle.svg \
 	hicolor/scalable/actions/longomatch-apply-button.svg \
 	hicolor/scalable/actions/longomatch-apply.svg \

--- a/data/icons/hicolor/scalable/actions/longomatch-alert.svg
+++ b/data/icons/hicolor/scalable/actions/longomatch-alert.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="20px" height="20px" viewBox="0 0 20 20" enable-background="new 0 0 20 20" xml:space="preserve">
+<g>
+	<g>
+		<path fill="#151A20" d="M3,17c-0.487,0-0.742,0.076-0.812-0.045c-0.07-0.121-0.065-0.304,0.178-0.726l7-12.07
+			C9.61,3.738,9.86,3.615,10,3.615s0.39,0.164,0.634,0.585l7,12.131c0.244,0.422,0.249,0.498,0.179,0.62
+			C17.742,17.073,17.487,17,17,17H3z"/>
+		<path fill="#C42527" d="M10,4.68L16.536,16H3.464L10,4.68 M10,2.643C9.457,2.643,8.913,3,8.5,3.714l-7,11.907
+			C0.675,17.049,1.35,18,3,18h14c1.65,0,2.325-0.951,1.5-2.379l-7-12.016C11.087,2.891,10.543,2.643,10,2.643L10,2.643z"/>
+	</g>
+	<g>
+		<path fill="#FFFFFF" d="M11,11c0,0.55-0.45,1-1,1l0,0c-0.55,0-1-0.45-1-1V8c0-0.55,0.45-1,1-1l0,0c0.55,0,1,0.45,1,1V11z"/>
+	</g>
+	<g>
+		<path fill="#FFFFFF" d="M11,15c0,0.55-0.45,1-1,1l0,0c-0.55,0-1-0.45-1-1l0,0c0-0.55,0.45-1,1-1l0,0C10.55,14,11,14.45,11,15
+			L11,15z"/>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
-Add new icon longomatch-alert.svg and updated the path in StyleConf.cs
-Changed the way a file is loaded into a project, instead of passing the project
in the parameter of selectMediaFiles method we pass the MediaFIleSet of the project.
-Changed the ButtonObject and DashboardButtonObject to a better use of properties when drawing the buttons.
-Change in ProjectManager to adapt to the new parameter in SelectMediaFIles.
-Changed tests to adapt to the new parameter in SelectMediaFiles.
- control in UpdateSelection if canvas objects is not selectable, return on UpdateSelection if the selection done is not a ICanvasSelectableObject