### PR TITLE
LON-668

### DIFF
--- a/LongoMatch.Drawing/CanvasObjects/Teams/PlayersTaggerObject.cs
+++ b/LongoMatch.Drawing/CanvasObjects/Teams/PlayersTaggerObject.cs
@@ -573,16 +573,18 @@ namespace LongoMatch.Drawing.CanvasObjects.Teams
 
 			playerObjects = new List<PlayerObject> ();
 			foreach (Player p in players) {
-				PlayerObject po = new PlayerObject { Player = p, Team = team };
-				po.ClickedEvent += HandlePlayerClickedEvent;
-				po.RedrawEvent += (co, area) => {
-					EmitRedrawEvent (po, area);
-				};
-				playerObjects.Add (po);
-				if (team == TeamType.LOCAL) {
-					homePlayerToPlayerObject.Add (p, po);
-				} else {
-					awayPlayerToPlayerObject.Add (p, po);
+				if (!homePlayerToPlayerObject.ContainsKey (p) && !awayPlayerToPlayerObject.ContainsKey (p)) {
+					PlayerObject po = new PlayerObject { Player = p, Team = team };
+					po.ClickedEvent += HandlePlayerClickedEvent;
+					po.RedrawEvent += (co, area) => {
+						EmitRedrawEvent (po, area);
+					};
+					playerObjects.Add (po);
+					if (team == TeamType.LOCAL) {
+						homePlayerToPlayerObject.Add (p, po);
+					} else {
+						awayPlayerToPlayerObject.Add (p, po);
+					}
 				}
 			}
 			return playerObjects;


### PR DESCRIPTION
Avoid adding a player that already exists in the team when tagging
Check if the player already exists when tagging on new project panel.