### PR TITLE
Fix regression drawing scalled canvas

### DIFF
--- a/LongoMatch.Drawing/Widgets/DashboardCanvas.cs
+++ b/LongoMatch.Drawing/Widgets/DashboardCanvas.cs
@@ -357,7 +357,6 @@ namespace LongoMatch.Drawing.Widgets
 			Begin (context);
 			DrawBackground ();
 			if (Mode != DashboardMode.Code) {
-				tk.TranslateAndScale (Translation, new Point (ScaleX, ScaleY));
 				/* Draw grid */
 				tk.LineWidth = 1;
 				tk.StrokeColor = Color.Grey1;


### PR DESCRIPTION
The translation was performed twice, in Canvas.End() and drawing
the grid