### PR TITLE
Fix memory exhaustion in the database migration in Windows

### DIFF
--- a/LongoMatch.Core/Store/Player.cs
+++ b/LongoMatch.Core/Store/Player.cs
@@ -27,7 +27,7 @@ namespace LongoMatch.Core.Store
 	/// Player of a team
 	/// </summary>
 	[Serializable]
-	public class Player: StorableBase
+	public class Player: StorableBase, IDisposable
 	{
 
 		#region Constructors
@@ -35,7 +35,12 @@ namespace LongoMatch.Core.Store
 		{
 			ID = Guid.NewGuid ();
 		}
-		
+
+		public void Dispose ()
+		{
+			Photo?.Dispose ();
+		}
+
 		#endregion
 
 		#region Properties

--- a/LongoMatch.Core/Store/Project.cs
+++ b/LongoMatch.Core/Store/Project.cs
@@ -49,7 +49,7 @@ namespace LongoMatch.Core.Store
 	/// </summary>
 	///
 	[Serializable]
-	public class Project : StorableBase, IComparable
+	public class Project : StorableBase, IComparable, IDisposable
 	{
 		public const int CURRENT_VERSION = 1;
 		ObservableCollection<TimelineEvent> timeline;
@@ -81,6 +81,16 @@ namespace LongoMatch.Core.Store
 		{
 			foreach (TimelineEvent evt in Timeline) {
 				evt.Project = this;
+			}
+		}
+
+		public void Dispose ()
+		{
+			LocalTeamTemplate?.Dispose ();
+			VisitorTeamTemplate?.Dispose ();
+			Dashboard?.Dispose ();
+			foreach (TimelineEvent evt in Timeline) {
+				evt.Dispose ();
 			}
 		}
 
@@ -284,19 +294,6 @@ namespace LongoMatch.Core.Store
 		#endregion
 
 		#region Public Methods
-
-		/// <summary>
-		/// Frees all the project's resources helping the GC
-		/// </summary>
-		public void Clear ()
-		{
-			Timeline.Clear ();
-			Dashboard.List.Clear ();
-			VisitorTeamTemplate.List.Clear ();
-			LocalTeamTemplate.List.Clear ();
-			Periods.Clear ();
-			Timers.Clear ();
-		}
 
 		public void UpdateScore ()
 		{

--- a/LongoMatch.Core/Store/Templates/Dashboard.cs
+++ b/LongoMatch.Core/Store/Templates/Dashboard.cs
@@ -37,7 +37,7 @@ namespace LongoMatch.Core.Store.Templates
 	/// in a grid to code events in a the game's timeline.
 	/// </summary>
 	[Serializable]
-	public class Dashboard: StorableBase, ITemplate<Dashboard>
+	public class Dashboard: StorableBase, ITemplate<Dashboard>, IDisposable
 	{
 
 		public const int CURRENT_VERSION = 1;
@@ -61,6 +61,16 @@ namespace LongoMatch.Core.Store.Templates
 			List = new ObservableCollection<DashboardButton> ();
 			GamePeriods = new ObservableCollection<string> { "1", "2" };
 			Version = Constants.DB_VERSION;
+		}
+
+		public void Dispose ()
+		{
+			FieldBackground?.Dispose ();
+			HalfFieldBackground?.Dispose ();
+			GoalBackground?.Dispose ();
+			foreach (var button in List) {
+				button.BackgroundImage?.Dispose ();
+			}
 		}
 
 		/// <summary>

--- a/LongoMatch.Core/Store/Templates/Team.cs
+++ b/LongoMatch.Core/Store/Templates/Team.cs
@@ -30,7 +30,7 @@ using Newtonsoft.Json;
 namespace LongoMatch.Core.Store.Templates
 {
 	[Serializable]
-	public class Team: StorableBase, ITemplate<Team>
+	public class Team: StorableBase, IDisposable, ITemplate<Team>
 	{
 		public const int CURRENT_VERSION = 1;
 		const int MAX_WIDTH = 100;
@@ -53,6 +53,14 @@ namespace LongoMatch.Core.Store.Templates
 			Colors [0] = Color.Blue1;
 			Colors [1] = Color.Red1;
 			Version = Constants.DB_VERSION;
+		}
+
+		public void Dispose ()
+		{
+			Shield?.Dispose ();
+			foreach (Player p in List) {
+				p.Dispose ();
+			}
 		}
 
 		[JsonIgnore]

--- a/LongoMatch.Core/Store/TimelineEvent.cs
+++ b/LongoMatch.Core/Store/TimelineEvent.cs
@@ -35,7 +35,7 @@ namespace LongoMatch.Core.Store
 	/// </summary>
 
 	[Serializable]
-	public class TimelineEvent : PixbufTimeNode, IStorable
+	public class TimelineEvent : PixbufTimeNode, IStorable, IDisposable
 	{
 		[NonSerialized]
 		IStorage storage;
@@ -57,6 +57,14 @@ namespace LongoMatch.Core.Store
 			Rate = 1.0f;
 			ID = Guid.NewGuid ();
 			CamerasConfig = new ObservableCollection<CameraConfig> { new CameraConfig (0) };
+		}
+
+		public void Dispose ()
+		{
+			Miniature?.Dispose ();
+			foreach (var drawing in Drawings) {
+				drawing.Miniature?.Dispose ();
+			}
 		}
 
 		#endregion

--- a/LongoMatch.DB/Migration/DatabaseMigration.cs
+++ b/LongoMatch.DB/Migration/DatabaseMigration.cs
@@ -223,7 +223,6 @@ namespace LongoMatch.DB
 			float totalProjects = projectFiles.Count * 2;
 			float percent = 0;
 			List<Task> tasks = new List<Task> ();
-			ConcurrentQueue<Project> projects = new ConcurrentQueue<Project> ();
 			bool ret = true;
 
 			Log.Information ("Start migrating " + databaseName);
@@ -244,40 +243,33 @@ namespace LongoMatch.DB
 					try {
 						Log.Information ("Migrating project " + projectFile);
 						project = Serializer.Instance.Load<Project> (projectFile);
-						if (project != null) {
-							projects.Enqueue (project);
-						}
 					} catch (Exception ex) {
 						Log.Exception (ex);
 						ret = false;
 					}
 					percent += 1 / totalProjects;
 					progress.Report (percent, "Imported project " + project?.Description.Title, id);
-				});
-				tasks.Add (importTask);
-			}
-			Task.WaitAll (tasks.ToArray ());
 
-			foreach (Project project in projects) {
-				if (project.LocalTeamTemplate.ID != Guid.Empty) {
-					teamNameToID [project.LocalTeamTemplate.Name] = project.LocalTeamTemplate.ID;
-				}
-				if (project.VisitorTeamTemplate.ID != Guid.Empty) {
-					teamNameToID [project.VisitorTeamTemplate.Name] = project.VisitorTeamTemplate.ID;
-				}
-			}
-
-			foreach (Project project in projects) {
-				var importTask = Task.Run (() => {
-					try {
-						ProjectMigration.Migrate0 (project, scoreNameToID, penaltyNameToID, teamNameToID, dashboardNameToID);
-						database.Store<Project> (project, true);
-					} catch (Exception ex) {
-						Log.Exception (ex);
-						ret = false;
+					if (project != null) {
+						if (project.LocalTeamTemplate.ID != Guid.Empty) {
+							teamNameToID [project.LocalTeamTemplate.Name] = project.LocalTeamTemplate.ID;
+						}
+						if (project.VisitorTeamTemplate.ID != Guid.Empty) {
+							teamNameToID [project.VisitorTeamTemplate.Name] = project.VisitorTeamTemplate.ID;
+						}
+						try {
+							ProjectMigration.Migrate0 (project, scoreNameToID, penaltyNameToID, teamNameToID, dashboardNameToID);
+							database.Store<Project> (project, true);
+						} catch (Exception ex) {
+							Log.Exception (ex);
+							ret = false;
+						}
+						percent += 1 / totalProjects;
+						progress.Report (percent, "Migrated project " + project?.Description.Title, id);
+						project.Dispose ();
+						project = null;
+						GC.Collect ();
 					}
-					percent += 1 / totalProjects;
-					progress.Report (percent, "Migrated project " + project?.Description.Title, id);
 				});
 				tasks.Add (importTask);
 			}


### PR DESCRIPTION
In the migration, we where loading all the projects in a DB
into memory and than adding them one by one the DB, so for
very big database, the mormoy was quickly exhausted in Windows
where the 32bits process can only allocate 2GB.
The Garbage Collector was also having problem to release correctly
all the memory allocated by a projects once it was processed, so now
a project is IDisposble, allowing us to release Image memory
as fast as possible